### PR TITLE
fix netdata and influxdb configuration

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -100,8 +100,12 @@ ynh_add_nginx_config
 #=================================================
 ynh_script_progression --message="Configuring Grafana and InfluxDB..." --weight=30
 # If NetData is installed, configure it to feed InfluxDB
-netdata_conf="/opt/netdata/etc/netdata/exporting.conf"
-if [ -f "$netdata_conf" ] ; then
+netdata_conf_dir="/opt/netdata/etc/netdata"
+if [ -d "$netdata_conf_dir" ] ; then
+  netdata_conf="$netdata_conf_dir/exporting.conf"
+  if [ ! -f "$netdata_conf" ] ; then
+    env EDITOR=true "$netdata_conf_dir/edit-config" exporting.conf
+  fi
   sed -i '/^\[exporting:global\]$/,/^\[/ {
         s/enabled = no/enabled = yes/
         s/# update every = 10/update every = 60/
@@ -128,7 +132,7 @@ fi
 
 # Configure InfluxDB
 if [ -f /etc/influxdb/influxdb.conf ] ; then
-  sed -i '/^\[\[opentsdb\]\]$/,/^\[/ s/enabled = false/enabled = true/' /etc/influxdb/influxdb.conf
+  sed -i '/^\[\[opentsdb\]\]$/,/^\[/ s/^[#:space:]*enabled = \(true\|false\)/enabled = true/' /etc/influxdb/influxdb.conf
 else
   [ -d /etc/influxdb ] || mkdir /etc/influxdb
   cp ../conf/influxdb.conf /etc/influxdb


### PR DESCRIPTION
Note: I have NOT tested the script as a whole, only relevant bits.

This should fix issue https://github.com/YunoHost-Apps/grafana_ynh/issues/23. As of now the install script fails to configure netdata and influxdb. With this patch it should:

- see that netstat is installed even if `exporting.conf` doesn't exist
- create `exporting.conf` if it doesn't exist
- uncomment the opentsdb `enabled = true` line in `influxdb.conf` if it is commented

