### PR TITLE
[Security fix] update to v8.0.7 + chg, use direct url not repo

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Metric & analytic dashboards for monitoring",
         "fr": "Tableaux de bords de supervision"
     },
-    "version": "8.0.6~ynh1",
+    "version": "8.0.7~ynh1",
     "license": "AGPL-3.0-only",
     "url": "https://grafana.com/oss/grafana/",
     "upstream": {

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,10 +5,38 @@
 #=================================================
 
 # Debian package version for Grafana
-GRAFANA_VERSION="8.0.7"
+GRAFANAVERSION="8.0.7"
 
 # dependencies used by the app
 pkg_dependencies="influxdb"
+
+ARCHITECTURE=$(dpkg --print-architecture)
+
+#arm64
+sha256_arm64=ebfa946af9e5414a9dd9cfc83cb6973fbfb366b81790f19d9dd0fd563142282d
+
+#armv6
+sha256_armhf_v6=78ae6990b3d4787f825278300c5779bcc1c89e5cb8ccbf6d7040aab421bb9948
+
+#armv7
+sha256_armhf=5b24999e1da04a6031ecca1a1a95386f87b4b23bbd0c59f61ebeea18557b5877
+
+#amd64
+sha256_amd64=ddfdd290c94768c2538b8546fd6c0ed2a0f0d2f3a5501e73a97f18edf4b9a167
+
+url=https://dl.grafana.com/enterprise/release/grafana-enterprise_${GRAFANAVERSION}_$ARCHITECTURE.deb
+
+url_armv6=https://dl.grafana.com/enterprise/release/grafana-enterprise-rpi_${GRAFANAVERSION}_$ARCHITECTURE.deb
+
+if [ -n "$(uname -m | grep armv6)" ]
+then
+    grafana_deb_url="$url_armv6"
+    sha256sum=sha256_armhf_v6
+else
+    grafana_deb_url="$url"
+    sha256sumvar=sha256_${ARCHITECTURE}
+    sha256sum=${!sha256sumvar}
+fi
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # Debian package version for Grafana
-GRAFANA_VERSION="7.5.5"
+GRAFANA_VERSION="8.0.7"
 
 # dependencies used by the app
 pkg_dependencies="influxdb"

--- a/scripts/install
+++ b/scripts/install
@@ -82,7 +82,7 @@ else
 fi
 
 ynh_exec_quiet "wget -q -O $grafana_deb_dst $grafana_deb_url"
-echo "$sha256sum  grafana_deb_dst" | sha256sum -c -
+echo "$sha256sum  $grafana_deb_dst" | sha256sum -c -
 
 ynh_script_progression --message="Installing Grafana..." --weight=11
     DEBIAN_FRONTEND=noninteractive ynh_exec_warn_less dpkg --force-confold -i $grafana_deb_dst

--- a/scripts/install
+++ b/scripts/install
@@ -61,10 +61,30 @@ ynh_app_setting_set --app=$app --key=port --value=$port
 #=================================================
 # INSTALL DEPENDENCIES
 #=================================================
-ynh_script_progression --message="Installing dependencies..." --weight=44
+ynh_script_progression --message="Installing dependencies..." --weight=22
 
 ynh_install_app_dependencies $pkg_dependencies
-ynh_install_extra_app_dependencies --repo="deb https://packages.grafana.com/oss/deb stable main" --package="grafana" --key="https://packages.grafana.com/gpg.key"
+
+#=================================================
+# DOWNLOAD  AND INSTALL GRAFANA DEB PACKAGE
+#=================================================
+ynh_script_progression --message="Downloading Grafana..." --weight=11
+
+temp_folder="$(mktemp -d)"
+
+grafana_deb_dst="$temp_folder/grafana_deb.deb"
+
+if [ -n "$(uname -m | grep armv6)" ]
+then
+    grafana_deb_url="$url_armv6"
+else
+    grafana_deb_url="$url"
+fi
+
+ynh_exec_quiet "wget -q -O $grafana_deb_dst $grafana_deb_url"
+
+ynh_script_progression --message="Installing Grafana..." --weight=11
+    DEBIAN_FRONTEND=noninteractive ynh_exec_warn_less dpkg --force-confold -i $grafana_deb_dst
 
 #=================================================
 # CREATE A MYSQL DATABASE

--- a/scripts/install
+++ b/scripts/install
@@ -82,6 +82,7 @@ else
 fi
 
 ynh_exec_quiet "wget -q -O $grafana_deb_dst $grafana_deb_url"
+echo "$sha256sum  grafana_deb_dst" | sha256sum -c -
 
 ynh_script_progression --message="Installing Grafana..." --weight=11
     DEBIAN_FRONTEND=noninteractive ynh_exec_warn_less dpkg --force-confold -i $grafana_deb_dst

--- a/scripts/remove
+++ b/scripts/remove
@@ -50,6 +50,7 @@ ynh_script_progression --message="Removing dependencies..." --weight=26
 
 # Remove metapackage and its dependencies
 ynh_remove_app_dependencies
+ynh_exec_warn_less dpkg -r grafana
 
 #=================================================
 # REMOVE NGINX CONFIGURATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -58,7 +58,27 @@ ynh_script_progression --message="Reinstalling dependencies..." --weight=24
 
 # Define and install dependencies
 ynh_install_app_dependencies $pkg_dependencies
-ynh_install_extra_app_dependencies --repo="deb https://packages.grafana.com/oss/deb stable main" --package="grafana" --key="https://packages.grafana.com/gpg.key"
+
+#=================================================
+# DOWNLOAD  AND REINSTALL GRAFANA DEB PACKAGE
+#=================================================
+ynh_script_progression --message="Downloading Grafana..." --weight=11
+
+temp_folder="$(mktemp -d)"
+
+grafana_deb_dst="$temp_folder/grafana_deb.deb"
+
+if [ -n "$(uname -m | grep armv6)" ]
+then
+    grafana_deb_url="$url_armv6"
+else
+    grafana_deb_url="$url"
+fi
+
+ynh_exec_quiet "wget -q -O $grafana_deb_dst $grafana_deb_url"
+
+ynh_script_progression --message="Installing Grafana..." --weight=11
+    DEBIAN_FRONTEND=noninteractive ynh_exec_warn_less dpkg --force-confold -i $grafana_deb_dst
 
 #=================================================
 # RESTORE THE MYSQL DATABASE

--- a/scripts/restore
+++ b/scripts/restore
@@ -76,7 +76,7 @@ else
 fi
 
 ynh_exec_quiet "wget -q -O $grafana_deb_dst $grafana_deb_url"
-echo "$sha256sum  grafana_deb_dst" | sha256sum -c -
+echo "$sha256sum  $grafana_deb_dst" | sha256sum -c -
 
 ynh_script_progression --message="Installing Grafana..." --weight=11
     DEBIAN_FRONTEND=noninteractive ynh_exec_warn_less dpkg --force-confold -i $grafana_deb_dst

--- a/scripts/restore
+++ b/scripts/restore
@@ -76,6 +76,7 @@ else
 fi
 
 ynh_exec_quiet "wget -q -O $grafana_deb_dst $grafana_deb_url"
+echo "$sha256sum  grafana_deb_dst" | sha256sum -c -
 
 ynh_script_progression --message="Installing Grafana..." --weight=11
     DEBIAN_FRONTEND=noninteractive ynh_exec_warn_less dpkg --force-confold -i $grafana_deb_dst

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -103,6 +103,7 @@ else
 fi
 
 ynh_exec_quiet "wget -q -O $grafana_deb_dst $grafana_deb_url"
+echo "$sha256sum  grafana_deb_dst" | sha256sum -c -
 
 ynh_script_progression --message="Installing Grafana..." --weight=11
     DEBIAN_FRONTEND=noninteractive ynh_exec_warn_less dpkg --force-confold -i $grafana_deb_dst

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -103,7 +103,7 @@ else
 fi
 
 ynh_exec_quiet "wget -q -O $grafana_deb_dst $grafana_deb_url"
-echo "$sha256sum  grafana_deb_dst" | sha256sum -c -
+echo "$sha256sum  $grafana_deb_dst" | sha256sum -c -
 
 ynh_script_progression --message="Installing Grafana..." --weight=11
     DEBIAN_FRONTEND=noninteractive ynh_exec_warn_less dpkg --force-confold -i $grafana_deb_dst

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -85,7 +85,27 @@ if [ -f "/etc/apt/sources.list.d/grafana_stable.list" ] ; then
 fi
 
 ynh_install_app_dependencies $pkg_dependencies
-ynh_install_extra_app_dependencies --repo="deb https://packages.grafana.com/oss/deb stable main" --package="grafana (=$GRAFANA_VERSION)" --key="https://packages.grafana.com/gpg.key"
+
+#=================================================
+# DOWNLOAD  AND INSTALL UPDATED GRAFANA DEB PACKAGE
+#=================================================
+ynh_script_progression --message="Downloading Grafana..." --weight=11
+
+temp_folder="$(mktemp -d)"
+
+grafana_deb_dst="$temp_folder/grafana_deb.deb"
+
+if [ -n "$(uname -m | grep armv6)" ]
+then
+    grafana_deb_url="$url_armv6"
+else
+    grafana_deb_url="$url"
+fi
+
+ynh_exec_quiet "wget -q -O $grafana_deb_dst $grafana_deb_url"
+
+ynh_script_progression --message="Installing Grafana..." --weight=11
+    DEBIAN_FRONTEND=noninteractive ynh_exec_warn_less dpkg --force-confold -i $grafana_deb_dst
 
 #=================================================
 # SPECIFIC UPGRADE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -85,7 +85,7 @@ if [ -f "/etc/apt/sources.list.d/grafana_stable.list" ] ; then
 fi
 
 ynh_install_app_dependencies $pkg_dependencies
-ynh_install_extra_app_dependencies --repo="deb https://packages.grafana.com/oss/deb stable main" --package="grafana (>=$GRAFANA_VERSION)" --key="https://packages.grafana.com/gpg.key"
+ynh_install_extra_app_dependencies --repo="deb https://packages.grafana.com/oss/deb stable main" --package="grafana (=$GRAFANA_VERSION)" --key="https://packages.grafana.com/gpg.key"
 
 #=================================================
 # SPECIFIC UPGRADE


### PR DESCRIPTION
## Problem

- Security issue in v8.0.6 cf issue #38 

## Solution

- Update to v8.0.7
- As this version is not available is repo anymore we have to use direct URL to deb file

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
