### PR TITLE
Update influxdb to v2 (influxdb2)

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -8,7 +8,7 @@
 GRAFANA_VERSION="8.3.3"
 
 # dependencies used by the app
-pkg_dependencies="influxdb"
+pkg_dependencies="influxdb2"
 
 #=================================================
 # PERSONAL HELPERS


### PR DESCRIPTION
## Problem
Current version of InfluxDB includes the official Debian repository, which is not updated for a long time (probably 2018 or 2019): 

- Potential security issues as the Debian repository is not really maintained (https://github.com/influxdata/influxdb/issues/10638#issuecomment-1031550651)
- The upgrade from 1.x to 2.1 looks not that easy, and it will be required at some point in the future, when 1.x won’t be maintained anymore: better to start with v2 from the beginning
- the flux language looks like the future of Influx DB, more powerful: I’d like to start writing our queries with this, rather than changing everything in the future
- It includes basic dashboards (I could avoid Grafana for some easy monitoring)
- It includes an alert system (in case of data collection has an issue for instance)

## Solution

Move to influxdb2, using the repository of InfluxData

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
- [ ] Additional integrations (notably netdata) are disabled for now to keep it simple

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
