### PR TITLE
Fixes the netdata path in order to repair influxdb feeding

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Grafana"
 description.en = "Metric & analytic dashboards for monitoring"
 description.fr = "Tableaux de bord de supervision"
 
-version = "10.2.3~ynh1"
+version = "10.2.3~ynh2"
 
 maintainers = ["JimboJoe"]
 

--- a/scripts/install
+++ b/scripts/install
@@ -25,10 +25,10 @@ ynh_add_nginx_config
 ynh_script_progression --message="Configuring Grafana and InfluxDB..." --weight=30
 
 # If NetData is installed, configure it to feed InfluxDB
-if [ -d "/opt/netdata/etc/netdata" ] ; then
-  netdata_conf="/opt/netdata/etc/netdata/exporting.conf"
+if [ -d "/var/www/netdata/etc/netdata" ] ; then
+  netdata_conf="/var/www/netdata/etc/netdata/exporting.conf"
   if [ ! -f "$netdata_conf" ] ; then
-    cp "/opt/netdata/usr/lib/netdata/conf.d/exporting.conf" /opt/netdata/etc/netdata
+    cp "/var/www/netdata/usr/lib/netdata/conf.d/exporting.conf" /var/www/netdata/etc/netdata
   fi
   sed -i '/^\[exporting:global\]$/,/^\[/ {
         s/enabled = no/enabled = yes/

--- a/scripts/remove
+++ b/scripts/remove
@@ -39,7 +39,7 @@ ynh_remove_nginx_config
 ynh_script_progression --message="Removing various files..."
 
 # If NetData is installed, configure it not to feed InfluxDB any more
-netdata_conf="/opt/netdata/etc/netdata/exporting.conf"
+netdata_conf="/var/www/netdata/etc/netdata/exporting.conf"
 if [[ -f "$netdata_conf" ]] ; then
     sed -i '/^\[exporting:global\]$/,/^\[/ {
         s/enabled = yes/enabled = no/

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -40,10 +40,10 @@ ynh_add_nginx_config
 ynh_script_progression --message="Configuring Grafana and InfluxDB..." --weight=3
 
 # If NetData is installed, configure it to feed InfluxDB
-if [ -d "/opt/netdata" ] ; then
-  netdata_conf="/opt/netdata/etc/netdata/exporting.conf"
+if [ -d "/var/www/netdata" ] ; then
+  netdata_conf="/var/www/netdata/etc/netdata/exporting.conf"
   if [ ! -f $netdata_conf ] ; then
-    cp /opt/netdata/usr/lib/netdata/conf.d/exporting.conf $netdata_conf
+    cp /var/www/netdata/usr/lib/netdata/conf.d/exporting.conf $netdata_conf
   fi
   sed -i '/^\[exporting:global\]$/,/^\[/ {
         s/enabled = no/enabled = yes/
@@ -67,7 +67,7 @@ EOF
   fi
 
   # Remove obsolete NetData backend if in use
-  netdata_conf="/opt/netdata/etc/netdata/netdata.conf"
+  netdata_conf="/var/www/netdata/etc/netdata/netdata.conf"
   if [ -f "$netdata_conf" ] ; then
     # If there is already a [backend] section
     if [ -n "$(cat $netdata_conf | grep '\[backend\]')" ] ; then


### PR DESCRIPTION
## Problem

- Influxdb isn't fed by netdata due to the path of netdata being invalid in install files

## Solution

- Changed netdata path from /opt/netdata to /var/www/netdata/

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
