### PR TITLE
Fix ARM64 installation

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -11,14 +11,7 @@ source /usr/share/yunohost/helpers
 #=================================================
 ynh_script_progression "Setting up source files..."
 
-mkdir "$install_dir/source"
-if [[ $YNH_ARCH == "amd64" ]]
-then
-	ynh_setup_source --source_id="main" --dest_dir="$install_dir/source"
-elif [[ $YNH_ARCH == "arm64" ]]
-then
-	ynh_setup_source --source_id="arm64" --dest_dir="$install_dir/source"
-fi
+ynh_setup_source --source_id="main" --dest_dir="$install_dir/source"
 
 #=================================================
 # APP INITIAL CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -40,13 +40,7 @@ ynh_systemctl --action=stop
 #=================================================
 ynh_script_progression "Upgrading source files..."
 
-if [[ $YNH_ARCH == "amd64" ]]
-then
-	ynh_setup_source --source_id="main" --dest_dir="$install_dir/source" --full_replace
-elif [[ $YNH_ARCH == "arm64" ]]
-then
-	ynh_setup_source --source_id="arm64" --dest_dir="$install_dir/source" --full_replace
-fi
+ynh_setup_source --dest_dir="$install_dir/source" --full_replace=1
 
 #=================================================
 # UPDATE A CONFIG FILE


### PR DESCRIPTION
## Problem

- Install/upgrade on ARM64 fails - https://forum.yunohost.org/t/bug-on-grafana-update/41925

## Solution

- ARM64 no longer has separate source

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
