### PR TITLE
Add admin documentation: connecting Prometheus and Loki data sources

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,0 +1,98 @@
+## Connecting data sources
+
+A fresh Grafana has no data sources: on its own it does not collect any metrics or logs, so the dashboard list will stay empty. The easiest way to fill it on YunoHost is to combine Grafana with these apps from the catalog:
+
+- [Prometheus](https://apps.yunohost.org/app/prometheus) + [node_exporter](https://apps.yunohost.org/app/node_exporter) for **metrics** (CPU, RAM, disk, network…)
+- [Loki](https://apps.yunohost.org/app/loki) (bundles Promtail) for **logs**
+
+### Metrics: Prometheus + node_exporter
+
+1. Install the `prometheus` and `node_exporter` apps.
+
+2. Prometheus does not scrape node_exporter automatically. Append a scrape job to `/var/www/prometheus/prometheus.yml`:
+
+   ```yaml
+   scrape_configs:
+     - job_name: node
+       static_configs:
+         - targets: ["127.0.0.1:9100"]
+   ```
+
+   then run `systemctl restart prometheus`.
+
+3. In Grafana, go to *Connections → Data sources → Add data source → Prometheus*. The URL must contain the port **and** the installation path of the Prometheus app, because the YunoHost package runs Prometheus with a route prefix:
+
+   ```
+   http://localhost:<port><path>     e.g.  http://localhost:9090/prometheus
+   ```
+
+   You can look both values up with:
+
+   ```bash
+   yunohost app setting prometheus port
+   yunohost app setting prometheus path
+   ```
+
+   Note that the port is **not always 9090**: if that port is already taken on your server (for example by Cockpit), YunoHost automatically picks a different one during installation.
+
+4. To get a complete server dashboard without building anything yourself, go to *Dashboards → New → Import* and load dashboard ID **1860** ("Node Exporter Full") with the Prometheus data source you just created.
+
+### Logs: Loki + Promtail
+
+1. Install the `loki` app. It also sets up Promtail, the agent that reads log files and ships them to Loki.
+
+2. Promtail ships **without any scrape targets**, so out of the box no logs are collected at all. Create a drop-in file, e.g. `/etc/loki/promtail.d/scrape.yaml`:
+
+   ```yaml
+   scrape_configs:
+     - job_name: system
+       static_configs:
+         - targets: [localhost]
+           labels:
+             job: syslog
+             __path__: /var/log/syslog
+         - targets: [localhost]
+           labels:
+             job: auth
+             __path__: /var/log/auth.log
+     - job_name: nginx
+       static_configs:
+         - targets: [localhost]
+           labels:
+             job: nginx
+             __path__: /var/log/nginx/*.log
+   ```
+
+3. Most system logs (`/var/log/syslog`, `/var/log/nginx/*`) are only readable for the `adm` group. Allow the `loki` user to read them, then restart Promtail:
+
+   ```bash
+   usermod -aG adm loki
+   systemctl restart loki-promtail
+   ```
+
+   You can verify that lines are flowing with:
+
+   ```bash
+   curl -s http://127.0.0.1:9080/metrics | grep promtail_sent_entries_total
+   ```
+
+4. In Grafana, add a data source of type *Loki* with the URL `http://localhost:3100` (look the port up with `yunohost app setting loki port_http` if you changed it). Logs can then be browsed under *Explore*, for example with the query `{job="nginx"}`.
+
+### Bonus: reusing Netdata's metrics
+
+If the [Netdata](https://apps.yunohost.org/app/netdata) app is installed, its several thousand metrics (nginx, PHP-FPM, databases, per-application details…) can be pulled into Prometheus as well — no extra exporters needed. Add to `/var/www/prometheus/prometheus.yml`:
+
+```yaml
+  - job_name: netdata
+    metrics_path: /api/v1/allmetrics
+    params:
+      format: [prometheus]
+    honor_labels: true
+    scrape_interval: 30s
+    static_configs:
+      - targets: ["127.0.0.1:19999"]
+```
+
+## Limitations
+
+- Organizations creation doesn't play well with LDAP integration; it is disabled for standard users, but can't be disabled for administrators: **please do not create organizations**!

--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -1,0 +1,3 @@
+Grafana is installed, but it does not collect any data by itself — without a data source, the dashboard list will stay empty.
+
+To monitor your YunoHost server, the recommended companions are the **Prometheus** + **node_exporter** apps (metrics) and the **Loki** app (logs). See the *Documentation* tab of this app (ADMIN.md) for a step-by-step guide, including the YunoHost-specific data source URLs and a ready-to-use Promtail configuration.


### PR DESCRIPTION
## Problem

Grafana installs without any data source. New users end up with an empty dashboard list and no obvious next step — the catalog has all the right companion apps (`prometheus`, `node_exporter`, `loki`), but wiring them up involves several YunoHost-specific pitfalls that are documented nowhere:

- The Prometheus data source URL must include the app's **install path**, because the package runs Prometheus with `--web.route-prefix` (e.g. `http://localhost:9090/prometheus`). And the port is not always 9090 — YunoHost picks a different one if it is taken (e.g. by Cockpit on port 9090).
- The prometheus app does not scrape `node_exporter` automatically; a scrape job has to be added manually.
- Promtail (bundled with the loki app) ships **without any scrape targets**, so out of the box zero logs are collected, silently.
- The `loki` user cannot read `/var/log/syslog` / nginx logs without being added to the `adm` group.

I hit every single one of these when setting this stack up on my own YunoHost server this week.

## Changes

- **doc/ADMIN.md** (new): step-by-step guide for connecting Prometheus + node_exporter (metrics) and Loki + Promtail (logs), covering the pitfalls above, plus importing dashboard 1860 ("Node Exporter Full") and optionally scraping Netdata's Prometheus endpoint.
- **doc/POST_INSTALL.md** (new): short post-install note pointing users to that guide, so they know Grafana needs a data source before anything shows up.

Documentation only — no changes to scripts or configuration. All commands and URLs were verified against live installations of grafana 13.1.0~ynh1, prometheus 3.12.0~ynh1 and loki 3.6.7~ynh1 on YunoHost 12 (Debian 13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)